### PR TITLE
Revert "move helpers to composer"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,7 @@
         "psr-4": {
             "LaravelViews\\": "src",
             "LaravelViews\\Test\\": "tests"
-        },
-        "files": [
-            "src/helpers.php"
-        ]
+        }
     },
     "require-dev": {
         "phpunit/phpunit": "6.0.*|7.0.*|8.5.*",

--- a/src/LaravelViewsServiceProvider.php
+++ b/src/LaravelViewsServiceProvider.php
@@ -23,7 +23,10 @@ class LaravelViewsServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        //
+        $file =  __DIR__ . '/helpers.php';
+        if (file_exists($file)) {
+            require_once($file);
+        }
     }
 
     /**


### PR DESCRIPTION
Reverts Gustavinho/laravel-views#15

I had to revert this PR because the helper wasn't loaded outside the package, I don't know why, I gonna keep an eye on it