### PR TITLE
Fix/issue when having two redirection action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.0.3] - NOT RELEASED YET
+### Fixed
+- Fixed a bug using multiple redirect actions on the same table
+- Fixed some typos on the documentation
+
+### Changed
+- Moved helpers load to composer
+
 ## [1.0.2] - 2020-07-13
 ### Fixed
 - Added support for newer livewire versions

--- a/src/Actions/RedirectAction.php
+++ b/src/Actions/RedirectAction.php
@@ -13,6 +13,9 @@ class RedirectAction extends Action
         $this->title = $title;
         $this->icon = $icon;
         $this->to = $to;
+
+        // Overrides the original id to create different ids for each redirect action
+        $this->id = $this->id . '-' . $this->to;
     }
 
     public function handle($item)

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -18,7 +18,9 @@ function attributes($attributes = null)
     return $attributesStr;
 }
 
-function variants()
-{
-    return new Variants;
+if (!function_exists('variants')) {
+    function variants()
+    {
+        return new Variants;
+    }
 }

--- a/tests/Feature/TableViewTest.php
+++ b/tests/Feature/TableViewTest.php
@@ -8,6 +8,7 @@ use LaravelViews\Test\Mock\MockTableViewWithActions;
 use LaravelViews\Test\Mock\MockTableViewWithSearchAndFilters;
 use LaravelViews\Test\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use LaravelViews\Test\Mock\MockTableViewWithRedirectActions;
 use Livewire\Livewire;
 
 class TableViewTest extends TestCase
@@ -120,6 +121,20 @@ class TableViewTest extends TestCase
             ->assertSee('Action was executed successfully')
             ->call('flushMessage')
             ->assertDontSee('Action was executed successfully');
+    }
+
+    public function testSeeMultipleRedirectActions()
+    {
+        $icons = ['eye', 'pencil'];
+        $class = 'mr-2 text-gray-400 hover:text-blue-600 transition-all duration-300 ease-in-out focus:text-blue-600 active:text-blue-600';
+
+        factory(UserTest::class)->create();
+
+        $table = Livewire::test(MockTableViewWithRedirectActions::class);
+
+        foreach ($icons as $icon) {
+            $table->assertSeeHtml('<i data-feather="' . $icon . '" class="' . $class . '"></i>');
+        }
     }
 
     private function assertSeeUsers($livewire, $users, $assert = 'assertSee')

--- a/tests/Mock/MockTableViewWithRedirectActions.php
+++ b/tests/Mock/MockTableViewWithRedirectActions.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace LaravelViews\Test\Mock;
+
+use LaravelViews\Actions\Action;
+use LaravelViews\Actions\RedirectAction;
+use LaravelViews\Filters\Filter;
+
+class MockTableViewWithRedirectActions extends MockTableView
+{
+    protected function actionsByRow()
+    {
+        return [
+            new RedirectAction('user', 'See user', 'eye'),
+            new RedirectAction('user.edit', 'Edit user', 'pencil'),
+        ];
+    }
+}

--- a/tests/Unit/RedirectActionTest.php
+++ b/tests/Unit/RedirectActionTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace LaravelViews\Test\Unit;
+
+use LaravelViews\Actions\RedirectAction;
+use LaravelViews\Test\TestCase;
+
+class RedirectActionTest extends TestCase
+{
+    public function testGenerateDynamicIdByRouteName()
+    {
+        $redirectAction = new RedirectAction('user', 'See user', 'eye');
+
+        $this->assertEquals($redirectAction->id, 'redirect-action-user');
+    }
+}

--- a/tests/Unit/VariantsTest.php
+++ b/tests/Unit/VariantsTest.php
@@ -4,9 +4,15 @@ namespace LaravelViews\Test\Unit;
 
 use LaravelViews\Facades\Variants;
 use LaravelViews\Test\TestCase;
+use LaravelViews\UI\Variants as UIVariants;
 
 class VariantsTest extends TestCase
 {
+    public function testVariantsHelper()
+    {
+        $this->assertInstanceOf(UIVariants::class, variants());
+    }
+
     public function testButtonVariants()
     {
         $this->assertEquals(


### PR DESCRIPTION
I fixed an issue when we have more than one redirect action on the same table view, all of them were resolving the same route because all of them had the same id, so I overrode the redirect action id to have different ids for each object