### PR TITLE
fixes query issue while searching on pivot

### DIFF
--- a/src/Data/TableViewSearchData.php
+++ b/src/Data/TableViewSearchData.php
@@ -20,13 +20,11 @@ class TableViewSearchData implements Searchable
     public function searchItems(Builder $query, $fields, $value): Builder
     {
         if ($value) {
-            foreach ($fields as $field) {
-                if ($field === reset($fields)) {
-                    $query->where($field, 'like', "%{$value}%");
-                } else {
+            $query->where(function ($query) use ($fields, $value) {
+                foreach ($fields as $field) {
                     $query->orWhere($field, 'like', "%{$value}%");
                 }
-            }
+            });
         }
 
         return $query;


### PR DESCRIPTION
Fixes issue #25. Updates the query to handle where condition in a proper way. 

In the current version, the query adds the `orWhere` to the end of the query which ignores the `and` conditions added previously. This PR fixes it by wrapping the `orWhere` in a `where` condition so that it doesn't ignore the previously applied condition. 
