### PR TITLE
feat: Add prevent to closing alert button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.0.5] - 2020-08-09
+### Fixed
+- Fixed default behavior clicking on actions adding a prevent directive
+
 ## [1.0.4] - 2020-07-26
 ### Fixed
 - Fixed some typos and syntax errors

--- a/resources/views/components/alert.blade.php
+++ b/resources/views/components/alert.blade.php
@@ -33,7 +33,7 @@ props
   </div>
 
   {{-- Flush this message from the session --}}
-  <a href="#" wire:click="{{ $onClose ?? ''}}">
+  <a href="#" wire:click.prevent="{{ $onClose ?? ''}}">
     <i data-feather="x-circle"></i>
   </a>
 </div>


### PR DESCRIPTION
I added a prevent directive on the closing alert button to avoid the default anchor behavior