### PR TITLE
Update table.blade.php to fix feather icons disappearing when clicking sort

### DIFF
--- a/resources/views/components/table.blade.php
+++ b/resources/views/components/table.blade.php
@@ -24,8 +24,12 @@ props:
                   {{ $header->title }}
                 </a>
                 <a href="#!" wire:click.prevent="sort('{{ $header->sortBy }}')" class="flex">
-                  <i data-feather="chevron-up" class="{{ $sortBy === $header->sortBy && $sortOrder === 'asc' ? 'text-gray-900' : 'text-gray-400'}} h-4 w-4"></i>
-                  <i data-feather="chevron-down" class="{{ $sortBy === $header->sortBy && $sortOrder === 'desc' ? 'text-gray-900' : 'text-gray-400'}} h-4 w-4"></i>
+                  <span wire:ignore>
+                    <i data-feather="chevron-up" class="{{ $sortBy === $header->sortBy && $sortOrder === 'asc' ? 'text-gray-900' : 'text-gray-400'}} h-4 w-4"></i>
+                  </span>
+                  <span wire:ignore>
+                    <i data-feather="chevron-down" class="{{ $sortBy === $header->sortBy && $sortOrder === 'desc' ? 'text-gray-900' : 'text-gray-400'}} h-4 w-4"></i>
+                  </span>
                 </a>
               </div>
             @else


### PR DESCRIPTION
When clicking sort the wire:ignore directive needs to span the sort chevron icons otherwise they disappear on click.

See https://github.com/livewire/livewire/issues/1083