### PR TITLE
Reset Pagination

### DIFF
--- a/src/Views/TableView.php
+++ b/src/Views/TableView.php
@@ -180,4 +180,18 @@ abstract class TableView extends View
         $this->confirmationMessage = null;
         $this->actionToBeConfirmed = null;
     }
+    
+    /**
+     * Reset pagination
+     */
+    
+    public function updatingSearch()
+    {
+        $this->resetPage();
+    }
+
+    public function updatingFilters()
+    {
+        $this->resetPage();
+    }
 }


### PR DESCRIPTION
When we are on a different page from the first one, and we carry out a search or we apply a filter, the value of the page is not set to one and it shows us the message that we do not have results when we have it, but in page one.