### PR TITLE
Refactor/refactor varians helper

### DIFF
--- a/resources/views/components/alert.blade.php
+++ b/resources/views/components/alert.blade.php
@@ -9,16 +9,16 @@ You can customize the variants classes in config/laravel-views.php
 --}}
 @props(['type' => 'success', 'onClose' => ''])
 
-<div class="fixed z-50 bottom-0 left-0 w-full p-4 md:w-1/2 md:top-0 md:right-0 md:p-8 md:left-auto xl:w-1/3 h-auto">
-  <div class="bg-white rounded p-4 flex items-center shadow-lg h-auto">
-    <div class="{{ variants()->alert($type)->class('icon') }} mr-4 rounded-full p-2">
-      <div class="{{ variants()->alert($type)->class('base') }} rounded-full p-1 border-2">
+<div class="fixed z-50 bottom-0 left-0 w-full p-4 md:w-1/2 md:top-0 md:right-0 md:p-8 md:left-auto xl:w-1/3 h-auto rounded">
+  <div class="bg-white rounded p-4 flex items-center shadow-lg h-auto border-gray-200 border">
+    <div class="{{ variants("alerts.{$type}.icon") }} mr-4 rounded-full p-2">
+      <div class="{{ variants("alerts.{$type}.base") }} rounded-full p-1 border-2">
         <i data-feather="{{ variants()->alert($type)->icon() }}" class="text-sm w-4 h-4 font-semibold"></i>
       </div>
     </div>
 
     <div class="flex-1">
-      <b class="{{ variants()->alert($type)->title('base') }} text-gray-900 font-semibold">
+      <b class="text-gray-900 font-semibold">
         {{ variants()->alert($type)->title() }}!
       </b>
       <div class="text-sm">
@@ -27,7 +27,7 @@ You can customize the variants classes in config/laravel-views.php
     </div>
 
     {{-- Flush this message from the session --}}
-    <button @click.prevent="{{ $onClose ?? ''}}">
+    <button @click.prevent="{{ $onClose ?? ''}}" class="text-gray-400 hover:text-gray-900 transition duration-300 ease-in-out cursor-pointer">
       <i data-feather="x-circle"></i>
     </button>
   </div>

--- a/resources/views/components/alerts-handler.blade.php
+++ b/resources/views/components/alerts-handler.blade.php
@@ -3,7 +3,7 @@
   x-init="@this.on('notify', (notification) => {
     open = true;
     message = notification.message;
-    setTimeout(() => { open = false }, 2500)
+    {{-- setTimeout(() => { open = false }, 2500) --}}
   })"
 >
   <div x-show='open'>

--- a/src/UI/Variants.php
+++ b/src/UI/Variants.php
@@ -10,6 +10,13 @@ class Variants
     /** @var String component's variant */
     private $variant;
 
+    private $path = null;
+
+    public function __construct($path = null)
+    {
+        $this->path = $path;
+    }
+
     /**
      * Uses the button component
      *
@@ -95,12 +102,17 @@ class Variants
      */
     public function class($element = '')
     {
-        $config = "laravel-views.{$this->component}.{$this->variant}";
-        if ($element) {
-            return config("{$config}.{$element}");
-        }
+        // Returns the config path directly it it was set in the constructor
+        if ($this->path) {
+            return config("laravel-views.{$this->path}");
+        } else {
+            $config = "laravel-views.{$this->component}.{$this->variant}";
+            if ($element) {
+                return config("{$config}.{$element}");
+            }
 
-        return config($config);
+            return config($config);
+        }
     }
 
     /**

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -2,22 +2,6 @@
 
 use LaravelViews\UI\Variants;
 
-function attributes($attributes = null)
-{
-    $attributesStr = '';
-    if ($attributes) {
-        foreach ($attributes as $attribute => $attrValue) {
-            if ($attribute) {
-                $attributesStr .= "$attribute = $attrValue ";
-            } else {
-                $attributesStr .= $attrValue . ' ';
-            }
-        }
-    }
-
-    return $attributesStr;
-}
-
 if (!function_exists('variants')) {
     function variants()
     {

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -3,8 +3,13 @@
 use LaravelViews\UI\Variants;
 
 if (!function_exists('variants')) {
-    function variants()
+    function variants($path = null)
     {
-        return new Variants;
+        $variants = new Variants($path);
+        if ($path) {
+            return $variants->class();
+        }
+
+        return $variants;
     }
 }

--- a/tests/Unit/VariantsTest.php
+++ b/tests/Unit/VariantsTest.php
@@ -20,6 +20,10 @@ class VariantsTest extends TestCase
             'text-white bg-blue-600 hover:bg-blue-500 focus:bg-blue-500 active:bg-blue-500'
         );
         $this->assertEquals(
+            variants('buttons.primary'),
+            'text-white bg-blue-600 hover:bg-blue-500 focus:bg-blue-500 active:bg-blue-500'
+        );
+        $this->assertEquals(
             Variants::button('primary-light')->class(),
             'text-blue-700 border border-blue-600 hover:bg-blue-600 hover:text-white focus:bg-blue-600 focus:text-white active:bg-blue-600 active:text-white'
         );

--- a/tests/Unit/VariantsTest.php
+++ b/tests/Unit/VariantsTest.php
@@ -15,12 +15,8 @@ class VariantsTest extends TestCase
 
     public function testButtonVariants()
     {
-        $this->assertEquals(
-            Variants::button('primary')->class(),
-            'text-white bg-blue-600 hover:bg-blue-500 focus:bg-blue-500 active:bg-blue-500'
-        );
-        $this->assertEquals(
-            variants('buttons.primary'),
+        $this->assertTrue(
+            Variants::button('primary')->class() ===
             'text-white bg-blue-600 hover:bg-blue-500 focus:bg-blue-500 active:bg-blue-500'
         );
         $this->assertEquals(
@@ -70,6 +66,24 @@ class VariantsTest extends TestCase
         $this->assertEquals(
             Variants::img()->class(),
             ''
+        );
+    }
+
+    public function testVarianstHelperUsingVariantPaths()
+    {
+        $this->assertEquals(
+            variants('images.avatar'),
+            'h-8 w-8 object-cover rounded-full shadow-inner'
+        );
+
+        $this->assertEquals(
+            variants('alerts.warning.title'),
+            'text-green-900'
+        );
+
+        $this->assertInstanceOf(
+            UIVariants::class,
+            variants()
         );
     }
 }


### PR DESCRIPTION
Refactored how the variants helper works using a string path instead of methods chained
Example

`variants('alerts.primary.title')`