### PR TITLE
added the current view object to the renderIf function

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,3 +183,20 @@ Here's the plan for what's coming:
 ### From 2.2 to 2.3
 - Clear your cached views `php artisan view:clear` since some of the internal components changed.
 - Update components
+- Update the renderIf() function in your action classes as follows: 
+  ```php
+  <?php
+
+  namespace App\Actions;
+
+  use LaravelViews\Actions\Action;
+  use LaravelViews\Views\View;          // new line
+
+  class YourAction extends Action
+  {
+      public function renderIf($item, View $view)       // add the view parameter
+      {
+          // your content
+      }
+  }
+  ```

--- a/doc/table-view.md
+++ b/doc/table-view.md
@@ -349,7 +349,7 @@ $this->error();
 You can choose if the action will be shown or hidden for an specific row defining a `renderIf` method and returning a boolean value, if you don't define this method the action will be shown aways.
 
 ```php
-public function renderIf($model)
+public function renderIf($model, View $view)
 {
     return !$model->active;
 }

--- a/doc/table-view.md
+++ b/doc/table-view.md
@@ -322,7 +322,7 @@ To display a success alert message you can execute the `$this->succes()` at the 
 ![](success.png)
 
 ```php
-public function handle($model)
+public function handle($model, View $view)
 {
     $model->active = true;
     $model->save();
@@ -346,7 +346,7 @@ $this->error();
 ![](error.png)
 
 ## Hiding actions
-You can choose if the action will be shown or hidden for an specific row defining a `renderIf` method and returning a boolean value, if you don't define this method the action will be shown aways.
+You can choose if the action will be shown or hidden for an specific row defining a `renderIf` method and returning a boolean value, if you don't define this method the action will be shown aways. The `handle` method receives the model corresponding to the row where the action was executed, and the current view where the action was executed from.
 
 ```php
 public function renderIf($model, View $view)

--- a/resources/views/components/actions/icon-and-title.blade.php
+++ b/resources/views/components/actions/icon-and-title.blade.php
@@ -1,7 +1,7 @@
 @props(['actions', 'model'])
 
 @foreach ($actions as $action)
-  @if ($action->renderIf($model))
+  @if ($action->renderIf($model, $this))
     <a href="#!" wire:click.prevent="executeAction('{{ $action->id }}', '{{ $model->getKey() }}', true)" title="{{ $action->title}}" class="group flex items-center px-4 py-2 text-gray-700 hover:bg-gray-100 hover:text-gray-900">
       <i data-feather="{{ $action->icon }}" class="mr-3 h-4 w-4 text-gray-600 group-hover:text-gray-700"></i>
       {{ $action->title }}

--- a/resources/views/components/actions/icon.blade.php
+++ b/resources/views/components/actions/icon.blade.php
@@ -1,7 +1,7 @@
 @props(['actions', 'model'])
 
 @foreach ($actions as $action)
-  @if ($action->renderIf($model))
+  @if ($action->renderIf($model, $this))
     <x-lv-icon-button :icon="$action->icon" size="sm" wire:click.prevent="executeAction('{{ $action->id }}', '{{ $model->getKey() }}', true)" />
   @endif
 @endforeach

--- a/src/Actions/Action.php
+++ b/src/Actions/Action.php
@@ -48,7 +48,7 @@ abstract class Action
         return strtolower(preg_replace('%([a-z])([A-Z])%', '\1-\2', $camelStr));
     }
 
-    public function renderIf($item)
+    public function renderIf($item, View $view)
     {
         return true;
     }


### PR DESCRIPTION
# Background 
I have just started using this package and I wanted to use the details view as an editing page. In order to do this in my ItemDetails livewire component I added a public property called $editing that is set to false by default.

I created a action called ToggleEditing that sets that property to true in my ItemDetails component. I also created a CancelEdting action that will do the opposite and set the $editing property to false. 

My issue then was that I don't want the ToggleEditing action button to appear while the page is in edit mode and I don't want the CancelEditing action button to appear when the page is not in edit mode. 

The renderIf function on the action button currently only accepts the $item as a parameter and so I made this pull request to add the Livewire component as a parameter in the renderIf function

# Example
![image](https://user-images.githubusercontent.com/71522167/118191147-60fb9700-b401-11eb-87bd-31a07e691094.png)
![image](https://user-images.githubusercontent.com/71522167/118191168-6822a500-b401-11eb-8d42-fef9759524a8.png)

```php
<?php

namespace App\Actions;

use LaravelViews\Actions\Action;
use LaravelViews\Views\View;

class ToggleEditing extends Action
{
    /**
     * Any title you want to be displayed
     * @var String
     * */
    public $title = "Edit Item";

    /**
     * This should be a valid Feather icon string
     * @var String
     */
    public $icon = "edit";

    /**
     * Execute the action when the user clicked on the button
     *
     * @param $model Model object of the list where the user has clicked
     * @param $view Current view where the action was executed from
     */
    public function handle($model, View $view)
    {
        $view->editing = true;
    }

    public function renderIf($item, $view)
    {
        return !$view->editing;
    }
}
```

# Breaking Change
Unfortunately even though this is a simple change it is not backwards compatible because a extra parameter has to be added to the renderIf function on the LaravelViews\Actions\Action class renderIf() function which breaks any existing action classes that override the renderIf() function. 

## Breaking change fix
If you have existing Actions where you have overridden the renderIf function change the function definition from 
```php
public function renderIf($item)
```

to

```php
public function renderIf($item, View $view)
```
