### PR TITLE
hotfix: make the alert container smaller

### DIFF
--- a/doc/table-view.md
+++ b/doc/table-view.md
@@ -22,7 +22,7 @@ This view creates a dynamic data table with some features like filters, paginati
 - [Actions](#actions)
     - [Registering actions](#registering-actions)
     - [Redirect action](#redirect-action)
-    - [Showing feedback messages](#showing-alert-messages)
+    - [Showing feedback messages](#showing-feedback-messages)
     - [Hiding actions](#hiding-actions)
     - [Confirmation message](#confirmation-message)
 - [Showing UI components](#showing-ui-components)

--- a/resources/views/components/alert.blade.php
+++ b/resources/views/components/alert.blade.php
@@ -18,7 +18,7 @@ props
   $alertType = isset($type) ? $type : 'success';
 @endphp
 
-<div class="fixed z-50 bottom-0 left-0 w-full p-4 md:w-1/2 md:top-0 md:bottom-auto md:right-0 md:p-8 md:left-auto xl:w-1/3">
+<div class="fixed z-50 bottom-0 left-0 w-full p-4 md:w-1/2 md:top-0 md:bottom-auto md:right-0 md:p-0 md:pt-8 md:pr-8 md:left-auto xl:w-1/3">
   <div class="{{ variants()->alert($alertType)->class('base') }} rounded p-4 flex items-center shadow-lg">
     <div class="{{ variants()->alert($alertType)->class('icon') }} mr-4 rounded-full p-2">
       <div class="{{ variants()->alert($alertType)->class('base') }} rounded-full p-1 border-2">

--- a/resources/views/components/alert.blade.php
+++ b/resources/views/components/alert.blade.php
@@ -18,7 +18,7 @@ props
   $alertType = isset($type) ? $type : 'success';
 @endphp
 
-<div class="fixed z-50 bottom-0 left-0 w-full p-4 md:w-1/2 md:top-0 md:right-0 md:p-8 md:left-auto xl:w-1/3">
+<div class="fixed z-50 bottom-0 left-0 w-full p-4 md:w-1/2 md:top-0 md:bottom-auto md:right-0 md:p-8 md:left-auto xl:w-1/3">
   <div class="{{ variants()->alert($alertType)->class('base') }} rounded p-4 flex items-center shadow-lg">
     <div class="{{ variants()->alert($alertType)->class('icon') }} mr-4 rounded-full p-2">
       <div class="{{ variants()->alert($alertType)->class('base') }} rounded-full p-1 border-2">


### PR DESCRIPTION
The alert container was blocking some of the UI because the bottom position was always set to 0, I fixed this by adding a `md:bottom-auto` class on the container, I also fixed the padding to avoid blocking the filters button in some cases.

### Container before
<img width="842" alt="Captura de Pantalla 2021-05-16 a la(s) 9 10 08 p m" src="https://user-images.githubusercontent.com/4228757/118423958-cbc00300-b68b-11eb-8c66-7a34206ba21d.png">

### Container after
<img width="852" alt="Captura de Pantalla 2021-05-16 a la(s) 9 17 07 p m" src="https://user-images.githubusercontent.com/4228757/118424242-789a8000-b68c-11eb-821d-76f8fb0f0a53.png">
