### PR TITLE
hotfix: Fix filters button positioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [2.2.4] - 2021-05-16
+### Fixed
+- Fixed alert container to avoid blocking the UI elements.
+- Fixed filers button positioning when there isn't a search textinput
+
+## [2.2.3] - 2021-04-14
+### Changed
+- Live demo URL in the docs
+## [2.2.2] - 2021-04-10
+### Fixed
+- Changed `$model->getKey()` insted of hardcoded `$model->id`
+
+## [2.2.1] - 2021-03-29
+### Fixed
+- Added `detail-view`, `grid-view` and `list-view` to the views to be published.
+
 ## [2.2] - 2021-03-01
 ### Added
 - New list view

--- a/resources/views/table-view/filters.blade.php
+++ b/resources/views/table-view/filters.blade.php
@@ -6,7 +6,7 @@ UI components used:
   - form/input-group
   - dropdown --}}
 
-<div class="flex flex-row">
+<div class="flex justify-end">
   {{-- Search input --}}
   @if ($searchBy)
     <div class="flex-1">

--- a/resources/views/table-view/table-view.blade.php
+++ b/resources/views/table-view/table-view.blade.php
@@ -13,7 +13,7 @@ UI components used:
 
 <div>
   {{-- Search input and filters --}}
-  <div class="p-4 pb-0">
+  <div class="py-4 px-3 pb-0">
     @include('laravel-views::table-view.filters')
   </div>
 


### PR DESCRIPTION
When there isn't a search text input the filter button was positioned to
the left of the screen, I added a `justify-end` class to position the
elements to the right

Additional changes
- I tweaked the filters padding to line it up with the cells padding
- Updated changelog since it wasn't up to date

### With a search text input
![May-16-2021 9-32-34 p m](https://user-images.githubusercontent.com/4228757/118426288-92d65d00-b690-11eb-9411-fd2e253d5156.gif)

### Without a search text input
![May-16-2021 9-32-56 p m](https://user-images.githubusercontent.com/4228757/118426323-9f5ab580-b690-11eb-8dc9-8a029a6cd3c4.gif)
