### PR TITLE
feat: Use a model class as initial data

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ php artisan make:table-view UsersTableView
 ```
 With this artisan command a UsersTableView.php file will be created inside the `app/Http/Livewire` directory.
 
-The basic usage needs a data repository (Eloquent query), headers and rows, you can customize the items to be shown, and the headers and data for each row like this example
+The basic usage needs a model class, headers and rows, you can customize the items to be shown, and the headers and data for each row like this example
 ```php
 <?php
 
@@ -87,10 +87,7 @@ use App\User;
 
 class UsersTableView extends TableView
 {
-    public function repository(): Builder
-    {
-        return User::query();
-    }
+    protected $model = User::class;
 
     public function headers(): array
     {
@@ -128,7 +125,7 @@ You could also use the `@livewire` blade directive.
 
 At this point, you would be able to see a table with some data, the table view doesn't have any styled container or title as the image example, you can render the table view inside any container you want.
 
-In the example above the view is using the User model created by default in every Laravel project, feel free to use any model you have, the method `row` is receiving a sinlge model object and you can use any property or public method you have difined inside your model.
+In the example above the view is using the User model created by default in every Laravel project, feel free to use any model you want, the method `row` is receiving a sinlge model object and you can use any property or public method you have difined inside your model.
 
 This is the basic usage of the table view, but you can customize it with more features.
 
@@ -183,7 +180,7 @@ Here's the plan for what's coming:
 ### From 2.2 to 2.3
 - Clear your cached views `php artisan view:clear` since some of the internal components changed.
 - Update components
-- Update the renderIf() function in your action classes as follows: 
+- Update the renderIf() function in your action classes as follows:
   ```php
   <?php
 
@@ -200,3 +197,4 @@ Here's the plan for what's coming:
       }
   }
   ```
+- **(Optional)**, if your `repository` methods are returning the query object without any query applied like `User::query()`, you can define a `protected $model = User::class;` instead, this is the default behavior now, the `repository` method is still working so you don't need to change anything if you don't want to.

--- a/doc/grid-view.md
+++ b/doc/grid-view.md
@@ -31,16 +31,32 @@ With this artisan command a `ExampleGridView.php` file will be created inside `a
 
 ## Defining initial data
 
-Return an `Eloquent` query with the initial data to be displayed on the grid view, it is important to return the query, not the data collection.
+The GridView class needs a model class to get the initial data to be displayed on the table, you can define it in the `$model` property.
 
 ```php
 use App\User;
 
+protected $model = User::class;
+```
+
+If you need an specific query as initial data you can define a `repository` method  returning an `Eloquent` query with the initial data to be displayed on the grid view, it is important to return the query, not the data collection.
+
+```php
+use App\User;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Sets a initial query with the data to fill the table
+ *
+ * @return Builder Eloquent query
+ */
 public function repository(): Builder
 {
     return User::query();
 }
 ```
+
+If you define this method, the `$model` property is not needed anymore.
 
 ## Defining card data
 

--- a/doc/list-view.md
+++ b/doc/list-view.md
@@ -31,16 +31,31 @@ With this artisan command an `ExampleListView.php` file will be created inside t
 
 ## Defining initial data
 
-You should return an `Eloquent` query with the initial data to be displayed on the list view, it is important to return the query, not the data collection.
+The ListView class needs a model class to get the initial data to be displayed on the table, you can define it in the `$model` property.
 
 ```php
 use App\User;
 
+protected $model = User::class;
+```
+
+If you need an specific query as initial data you can define a `repository` method  returning an `Eloquent` query with the initial data to be displayed on the list view, it is important to return the query, not the data collection.
+
+```php
+use App\User;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Sets a initial query with the data to fill the table
+ *
+ * @return Builder Eloquent query
+ */
 public function repository(): Builder
 {
     return User::query();
 }
 ```
+If you define this method, the `$model` property is not needed anymore.
 
 ## Defining data for each list item
 

--- a/doc/table-view.md
+++ b/doc/table-view.md
@@ -44,16 +44,32 @@ php artisan make:table-view UsersTableView
 With this artisan command a `UsersTableView.php` file will be created inside `app/Http/Livewire` directory, with this class you can customize the behavior of the table view.
 
 ## Defining initial data
-Return an `Eloquent` query with the initial data to be displayed on the table, it is important to return the query, not the data collection.
+The TableView class needs a model class to get the initial data to be displayed on the table, you can define it in the `$model` property.
 
 ```php
 use App\User;
 
+protected $model = User::class;
+```
+
+If you need an specific query as initial data you can define a `repository` method  returning an `Eloquent` query with the initial data to be displayed on the table, it is important to return the query, not the data collection.
+
+```php
+use App\User;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Sets a initial query with the data to fill the table
+ *
+ * @return Builder Eloquent query
+ */
 public function repository(): Builder
 {
     return User::query();
 }
 ```
+
+If you define this method, the `$model` property is not needed anymore.
 
 ## Headers
 Return an array with all the headers you need

--- a/src/Views/DataView.php
+++ b/src/Views/DataView.php
@@ -93,7 +93,11 @@ abstract class DataView extends View
      */
     public function getItems(Searchable $searchable, Filterable $filterable, Sortable $sortable)
     {
-        $query = $this->repository();
+        if (method_exists($this, 'repository')) {
+            $query = $this->repository();
+        } else {
+            $query = $this->model::query();
+        }
 
         $query = $searchable->searchItems($query, $this->searchBy, $this->search);
 

--- a/stubs/grid-view.stub
+++ b/stubs/grid-view.stub
@@ -8,14 +8,9 @@ use Illuminate\Database\Eloquent\Builder;
 class DummyClass extends GridView
 {
     /**
-     * Sets a initial query with the data to fill the grid view
-     *
-     * @return Builder Eloquent query
+     * Sets a model class to get the initial data
      */
-    public function repository(): Builder
-    {
-        // return User::query();
-    }
+    protected $model = User::class;
 
     /**
      * Sets the data to every card on the view

--- a/stubs/list-view.stub
+++ b/stubs/list-view.stub
@@ -8,14 +8,9 @@ use Illuminate\Database\Eloquent\Builder;
 class DummyClass extends ListView
 {
     /**
-     * Sets a initial query with the data to fill the table
-     *
-     * @return Builder Eloquent query
+     * Sets a model class to get the initial data
      */
-    public function repository(): Builder
-    {
-        // return User::query();
-    }
+    protected $model = User::class;
 
     /**
      * Sets the properties to every list item component

--- a/stubs/table-view.stub
+++ b/stubs/table-view.stub
@@ -3,19 +3,13 @@
 namespace DummyNamespace;
 
 use LaravelViews\Views\TableView;
-use Illuminate\Database\Eloquent\Builder;
 
 class DummyClass extends TableView
 {
     /**
-     * Sets a initial query with the data to fill the table
-     *
-     * @return Builder Eloquent query
+     * Sets a model class to get the initial data
      */
-    public function repository(): Builder
-    {
-        // return User::query();
-    }
+    protected $model = User::class;
 
     /**
      * Sets the headers of the table as you want to be displayed

--- a/tests/Feature/TableViewTest.php
+++ b/tests/Feature/TableViewTest.php
@@ -6,6 +6,7 @@ use LaravelViews\Test\Database\UserTest;
 use LaravelViews\Test\Mock\MockTableView;
 use LaravelViews\Test\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use LaravelViews\Test\Mock\MockTableViewWithModelClass;
 use Livewire\Livewire;
 
 class TableViewTest extends TestCase
@@ -28,6 +29,14 @@ class TableViewTest extends TestCase
         $users = factory(UserTest::class, 7)->create();
 
         Livewire::test(MockTableView::class)
+            ->assertSeeUsers($users);
+    }
+
+    public function testSeeAllDataSettingAModelClass()
+    {
+        $users = factory(UserTest::class, 7)->create();
+
+        Livewire::test(MockTableViewWithModelClass::class)
             ->assertSeeUsers($users);
     }
 }

--- a/tests/Mock/MockTableViewWithModelClass.php
+++ b/tests/Mock/MockTableViewWithModelClass.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace LaravelViews\Test\Mock;
+
+use LaravelViews\Test\Database\UserTest;
+use LaravelViews\Views\TableView;
+use Illuminate\Database\Eloquent\Builder;
+
+class MockTableViewWithModelClass extends TableView
+{
+    protected $model = UserTest::class;
+
+    public function headers()
+    {
+        return [
+            'name',
+            'email'
+        ];
+    }
+
+    public function row(UserTest $user)
+    {
+        return [
+            $user->name,
+            $user->email
+        ];
+    }
+}


### PR DESCRIPTION
I added a feature to set a model class as a property of the data views
to set the initial data by default, the `repository` method is still
working and it is used to set a more specific query.

- I updated the stubs
- I updated the documentation
- I updated the upgrade guide