### PR TITLE
Bug/with alpine3 inline editing is reseting the value

### DIFF
--- a/doc/laravel-views.md
+++ b/doc/laravel-views.md
@@ -17,8 +17,8 @@
 - [Components customization](#components-customization)
     - [Component variants using tailwindcss](#component-variants-using-tailwindcss)
     - [Components full customization](#components-full-customization)
-- [Table view](doc/table-view.md)
-- [Grid view](doc/grid-view.md)
+- [Table view](./table-view.md)
+- [Grid view](./grid-view.md)
 
 # Version compatibility
 |Laravel views|Alpine|Livewire|Laravel|

--- a/resources/views/components/editable.blade.php
+++ b/resources/views/components/editable.blade.php
@@ -17,7 +17,7 @@ Render an editable input field --}}
     x-model="value"
     @keydown.enter="$wire.update(id, {
       [field]: value
-    }); editing = false;"
+    }); editing = false; original = value"
     @keydown.escape="editing = false; value = original;"
     class="block appearance-none w-full bg-white border-gray-300 hover:border-gray-500 px-2 py-1 rounded focus:outline-none focus:bg-white focus:border-blue-600 focus:border-2 border">
   <div x-show="!editing"


### PR DESCRIPTION
After updating the value, if we click away from the input, the value was being reset to the original one, this was happening with alpine 3x.

To fix it, I set the original value to the newest value after editing 