### PR TITLE
Adding the option to sort tables with natural ordering

### DIFF
--- a/resources/views/components/table.blade.php
+++ b/resources/views/components/table.blade.php
@@ -27,10 +27,10 @@ props:
           @else
             @if ($header->isSortable())
               <div class="flex">
-                <a href="#!" wire:click.prevent="sort('{{ $header->sortBy }}')" class="flex-1">
+                <a href="#!" wire:click.prevent="sort('{{ $header->sortBy }}', {{ $header->sortNatural }})" class="flex-1">
                   {{ $header->title }}
                 </a>
-                <a href="#!" wire:click.prevent="sort('{{ $header->sortBy }}')" class="flex">
+                <a href="#!" wire:click.prevent="sort('{{ $header->sortBy }}', {{ $header->sortNatural }})" class="flex">
                   <i data-feather="chevron-up" class="{{ $sortBy === $header->sortBy && $sortOrder === 'asc' ? 'text-gray-900' : 'text-gray-400'}} h-4 w-4"></i>
                   <i data-feather="chevron-down" class="{{ $sortBy === $header->sortBy && $sortOrder === 'desc' ? 'text-gray-900' : 'text-gray-400'}} h-4 w-4"></i>
                 </a>

--- a/src/Data/Contracts/Sortable.php
+++ b/src/Data/Contracts/Sortable.php
@@ -11,9 +11,10 @@ interface Sortable
      *
      * @param Builder $query Current Eloquent query builder
      * @param String $field Field the query will be sort by
+     * @param Bool $sortnat Compare items as strings using "natural ordering" like natsort()
      * @param String $order Could be asc or desc
      *
      * @return Builder Updated Eloquent query builder
      */
-    public function sortItems(Builder $query, $field, $order = 'asc'): Builder;
+    public function sortItems(Builder $query, $field, $sortnat, $order = 'asc'): Builder;
 }

--- a/src/Data/Contracts/Sortable.php
+++ b/src/Data/Contracts/Sortable.php
@@ -11,7 +11,7 @@ interface Sortable
      *
      * @param Builder $query Current Eloquent query builder
      * @param String $field Field the query will be sort by
-     * @param Bool $sortnat Compare items as strings using "natural ordering" like natsort()
+     * @param Int $sortnat Compare items as strings using "natural ordering" like natsort()
      * @param String $order Could be asc or desc
      *
      * @return Builder Updated Eloquent query builder

--- a/src/Data/TableViewSortData.php
+++ b/src/Data/TableViewSortData.php
@@ -12,7 +12,7 @@ class TableViewSortData implements Sortable
      *
      * @param Builder $query Current Eloquent query builder
      * @param String $field Field the query will be sort by
-     * @param Bool $sortnat Compare items as strings using "natural ordering" like natsort()
+     * @param Int $sortnat Compare items as strings using "natural ordering" like natsort()
      * @param String $order Could be asc or desc
      *
      * @return Builder Updated Eloquent query builder
@@ -20,7 +20,7 @@ class TableViewSortData implements Sortable
     public function sortItems(Builder $query, $field, $sortnat, $order = 'asc'): Builder
     {
         if ($field) {
-            if ($sortnat == true) {
+            if ($sortnat == 1) {
                 $query->orderByRaw('LENGTH(' . $field . ') ' . $order . ', ' . $field . ' ' . $order);
             } else {
                 $query->orderBy($field, $order);

--- a/src/Data/TableViewSortData.php
+++ b/src/Data/TableViewSortData.php
@@ -12,14 +12,19 @@ class TableViewSortData implements Sortable
      *
      * @param Builder $query Current Eloquent query builder
      * @param String $field Field the query will be sort by
+     * @param Bool $sortnat Compare items as strings using "natural ordering" like natsort()
      * @param String $order Could be asc or desc
      *
      * @return Builder Updated Eloquent query builder
      */
-    public function sortItems(Builder $query, $field, $order = 'asc'): Builder
+    public function sortItems(Builder $query, $field, $sortnat, $order = 'asc'): Builder
     {
         if ($field) {
-            $query->orderBy($field, $order);
+            if ($sortnat == true) {
+                $query->orderByRaw('LENGTH(' . $field . ') ' . $order . ', ' . $field . ' ' . $order);
+            } else {
+                $query->orderBy($field, $order);
+            }
         }
 
         return $query;

--- a/src/UI/Header.php
+++ b/src/UI/Header.php
@@ -10,6 +10,9 @@ class Header
     /** @var string Field the table view will be sort by */
     public $sortBy;
 
+    /** @var bool Compare items as strings using "natural ordering" like natsort() */
+    public $sortNatural;
+
     /** @var string Width the width of the table column */
     public $width;
 
@@ -33,6 +36,18 @@ class Header
     public function sortBy(string $field)
     {
         $this->sortBy = $field;
+
+        return $this;
+    }
+
+    /**
+     * Sets the sort method
+     * @param bool $sortnat If the table view should be sorted by "natural ordering" like natsort()
+     * @return Header
+     */
+    public function sortNatural(bool $sortnat = true)
+    {
+        $this->sortNatural = $sortnat;
 
         return $this;
     }

--- a/src/UI/Header.php
+++ b/src/UI/Header.php
@@ -10,7 +10,7 @@ class Header
     /** @var string Field the table view will be sort by */
     public $sortBy;
 
-    /** @var bool Compare items as strings using "natural ordering" like natsort() */
+    /** @var int Compare items as strings using "natural ordering" like natsort() */
     public $sortNatural;
 
     /** @var string Width the width of the table column */
@@ -45,7 +45,7 @@ class Header
      * @param bool $sortnat If the table view should be sorted by "natural ordering" like natsort()
      * @return Header
      */
-    public function sortNatural(bool $sortnat = true)
+    public function sortNatural(int $sortnat = 1)
     {
         $this->sortNatural = $sortnat;
 

--- a/src/Views/DataView.php
+++ b/src/Views/DataView.php
@@ -17,6 +17,7 @@ abstract class DataView extends View
         'search' => ['except' => ''],
         'filters',
         'sortBy',
+        'sortNatural',
         'sortOrder'
     ];
 
@@ -43,6 +44,8 @@ abstract class DataView extends View
 
     public $sortBy = null;
 
+    public $sortNatural = false;
+
     public $sortOrder = 'asc';
 
     public $selected = [];
@@ -63,6 +66,7 @@ abstract class DataView extends View
         $this->applyDefaultFilters();
 
         $this->sortBy = $queryStringData->getValue('sortBy', $this->sortBy);
+        $this->sortNatural = $queryStringData->getValue('sortNatural', $this->sortNatural);
         $this->sortOrder = $queryStringData->getValue('sortOrder', $this->sortOrder);
     }
 
@@ -152,7 +156,7 @@ abstract class DataView extends View
         $query = clone $this->initialQuery;
         $query = $searchable->searchItems($query, $this->searchBy, $this->search);
         $query = $filterable->applyFilters($query, $this->filters(), $this->filters);
-        $query = $sortable->sortItems($query, $this->sortBy, $this->sortOrder);
+        $query = $sortable->sortItems($query, $this->sortBy, $this->sortNatural, $this->sortOrder);
 
         return $query;
     }
@@ -172,7 +176,7 @@ abstract class DataView extends View
      * Sets the field the table view data will be sort by
      * @param string $field Field to sort by
      */
-    public function sort($field)
+    public function sort($field, $sortnat = false)
     {
         if ($this->sortBy === $field) {
             $this->sortOrder = $this->sortOrder === 'asc' ? 'desc' : 'asc';
@@ -180,6 +184,8 @@ abstract class DataView extends View
             $this->sortBy = $field;
             $this->sortOrder = 'asc';
         }
+
+        $this->sortNatural = $sortnat;
     }
 
     public function clearFilters()

--- a/src/Views/DataView.php
+++ b/src/Views/DataView.php
@@ -44,7 +44,7 @@ abstract class DataView extends View
 
     public $sortBy = null;
 
-    public $sortNatural = false;
+    public $sortNatural = 0;
 
     public $sortOrder = 'asc';
 
@@ -176,7 +176,7 @@ abstract class DataView extends View
      * Sets the field the table view data will be sort by
      * @param string $field Field to sort by
      */
-    public function sort($field, $sortnat = false)
+    public function sort($field, $sortnat = 0)
     {
         if ($this->sortBy === $field) {
             $this->sortOrder = $this->sortOrder === 'asc' ? 'desc' : 'asc';


### PR DESCRIPTION
Currently, sorted table views will use regular ordering, which is not ideal for certain alphanumeric tables:

![image](https://user-images.githubusercontent.com/130062383/232465819-6fb181d7-c46f-42e1-808f-ff9eecadff45.png)


I have added a new `sortNatural()` method that can be added to the table headers, which will make it so that column will sort using natural ordering:

![image](https://user-images.githubusercontent.com/130062383/232466978-4d05f37c-109b-44ac-b283-f4a0035ceba0.png)
![image](https://user-images.githubusercontent.com/130062383/232467026-301788d1-99bf-4ef6-a3e6-40ccc4ce2ccb.png)


The ordering method will only change for the columns that have added this extra method. All other columns will utilise the existing regular ordering.